### PR TITLE
Better get plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ This plugin boilerplate was created by [Clifford Paulick](https://github.com/cli
 
 Documenting this project's progress...
 
+##### February 5, 2019
+* Renamed `wp_plugin_name_get_plugin_display_name()` to `get_plugin_display_name()` to remove prefix since we are within our own namespace.
+
 ##### February 1, 2019
 * Add `string_ends_with()` and `get_string_between_two_strings()` utility functions.
 

--- a/cliff-wp-plugin-boilerplate.php
+++ b/cliff-wp-plugin-boilerplate.php
@@ -207,23 +207,23 @@ if ( ! class_exists( 'WP_Plugin_Name' ) ) {
 				'strings'      => [
 					'notice_can_install_required'    => _n_noop(
 					// translators: 1: plugin name(s).
-						wp_plugin_name_get_plugin_display_name() . ' requires the following plugin: %1$s.',
-						wp_plugin_name_get_plugin_display_name() . ' requires the following plugins: %1$s.',
+						get_plugin_display_name() . ' requires the following plugin: %1$s.',
+						get_plugin_display_name() . ' requires the following plugins: %1$s.',
 						PLUGIN_TEXT_DOMAIN
 					),
 					'notice_can_install_recommended' => _n_noop(
 					// translators: 1: plugin name(s).
-						wp_plugin_name_get_plugin_display_name() . ' recommends the following plugin: %1$s.',
-						wp_plugin_name_get_plugin_display_name() . ' recommends the following plugins: %1$s.',
+						get_plugin_display_name() . ' recommends the following plugin: %1$s.',
+						get_plugin_display_name() . ' recommends the following plugins: %1$s.',
 						PLUGIN_TEXT_DOMAIN
 					),
 					'notice_ask_to_update'           => _n_noop(
 					// translators: 1: plugin name(s).
-						'The following plugin needs to be updated to its latest version to ensure maximum compatibility with ' . wp_plugin_name_get_plugin_display_name() . ': %1$s.',
-						'The following plugins need to be updated to their latest version to ensure maximum compatibility with ' . wp_plugin_name_get_plugin_display_name() . ': %1$s.',
+						'The following plugin needs to be updated to its latest version to ensure maximum compatibility with ' . get_plugin_display_name() . ': %1$s.',
+						'The following plugins need to be updated to their latest version to ensure maximum compatibility with ' . get_plugin_display_name() . ': %1$s.',
 						PLUGIN_TEXT_DOMAIN
 					),
-					'plugin_needs_higher_version'    => __( 'Plugin not activated. A higher version of %s is needed for ' . wp_plugin_name_get_plugin_display_name() . '. Please update the plugin.', PLUGIN_TEXT_DOMAIN ),
+					'plugin_needs_higher_version'    => __( 'Plugin not activated. A higher version of %s is needed for ' . get_plugin_display_name() . '. Please update the plugin.', PLUGIN_TEXT_DOMAIN ),
 					// translators: 1: dashboard link.
 					'nag_type'                       => 'error', // Determines admin notice type - can only be one of the typical WP notice classes, such as 'updated', 'update-nag', 'notice-warning', 'notice-info' or 'error'. Some of which may not work as expected in older WP versions.
 				],
@@ -238,7 +238,7 @@ if ( ! class_exists( 'WP_Plugin_Name' ) ) {
 		public function notice_old_php_version() {
 			$message = sprintf(
 				__( '%1$s requires at least PHP version %2$s in order to work.', PLUGIN_TEXT_DOMAIN ),
-				'<strong>' . wp_plugin_name_get_plugin_display_name() . '</strong>',
+				'<strong>' . get_plugin_display_name() . '</strong>',
 				'<strong>' . $this->min_php . '</strong>'
 			);
 
@@ -310,7 +310,7 @@ if ( ! class_exists( 'WP_Plugin_Name' ) ) {
 
 			$message = sprintf(
 				__( 'The %1$s plugin requires the %2$s parent theme%3$sin order to work.%4$s', PLUGIN_TEXT_DOMAIN ),
-				'<strong>' . wp_plugin_name_get_plugin_display_name() . '</strong>',
+				'<strong>' . get_plugin_display_name() . '</strong>',
 				'<strong>' . $parent_name . '</strong>',
 				$child_message,
 				$admin_link
@@ -472,7 +472,7 @@ if ( ! class_exists( 'WP_Plugin_Name' ) ) {
  *
  * @return string
  */
-function wp_plugin_name_get_plugin_display_name() {
+function get_plugin_display_name() {
 	return esc_html_x( 'WordPress Plugin Boilerplate', 'Plugin name for display', PLUGIN_TEXT_DOMAIN );
 }
 

--- a/src/admin/class-admin.php
+++ b/src/admin/class-admin.php
@@ -122,8 +122,8 @@ if ( ! class_exists( 'Admin' ) ) {
 		 */
 		public function add_plugin_admin_menu() {
 			add_options_page(
-				NS\wp_plugin_name_get_plugin_display_name(),
-				NS\wp_plugin_name_get_plugin_display_name(),
+				NS\get_plugin_display_name(),
+				NS\get_plugin_display_name(),
 				$this->common->required_capability(),
 				$this->get_settings_page_slug(),
 				[ $this, 'settings_page' ]
@@ -142,7 +142,7 @@ if ( ! class_exists( 'Admin' ) ) {
 
 			?>
 			<div class="wrap">
-				<h1><?php echo NS\wp_plugin_name_get_plugin_display_name() . ' ' . $this->get_settings_word();
+				<h1><?php echo NS\get_plugin_display_name() . ' ' . $this->get_settings_word();
 					?></h1>
 
 				<p><?php esc_html_e( "This plugin uses the WordPress Customizer to set its options.", $this->common->plugin_text_domain ); ?></p>

--- a/src/customizer/class-customizer.php
+++ b/src/customizer/class-customizer.php
@@ -67,7 +67,7 @@ if ( ! class_exists( 'Customizer' ) ) {
 			$wp_customize->add_panel(
 				$this->common->customizer_panel_id(),
 				[
-					'title'       => NS\wp_plugin_name_get_plugin_display_name(),
+					'title'       => NS\get_plugin_display_name(),
 					'description' => esc_html__( 'Plugin options and settings', $this->common->plugin_text_domain ) . $this->common->get_link_to_customizer_panel(),
 				]
 			);


### PR DESCRIPTION
Renamed `wp_plugin_name_get_plugin_display_name()` to `get_plugin_display_name()` to remove prefix since we are within our own namespace.