### PR TITLE
Error log

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ This plugin boilerplate was created by [Clifford Paulick](https://github.com/cli
 Documenting this project's progress...
 
 ##### February 5, 2019
+* Added `output_to_log()` utility function to *Common* to enable writing to `WP_DEBUG_LOG` and optionally send an email, such as to the site administrator.
 * Renamed `wp_plugin_name_get_plugin_display_name()` to `get_plugin_display_name()` to remove prefix since we are within our own namespace.
 
 ##### February 1, 2019

--- a/languages/cliff-wp-plugin-boilerplate.pot
+++ b/languages/cliff-wp-plugin-boilerplate.pot
@@ -3,8 +3,8 @@ msgid ""
 msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 "Project-Id-Version: WordPress Plugin Boilerplate\n"
-"POT-Creation-Date: 2019-01-31 17:28-0600\n"
-"PO-Revision-Date: 2019-01-31 17:28-0600\n"
+"POT-Creation-Date: 2019-02-05 17:34-0600\n"
+"PO-Revision-Date: 2019-02-05 17:34-0600\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -96,19 +96,34 @@ msgstr ""
 msgid "Edit Plugin Settings in WP Customizer"
 msgstr ""
 
-#: src/common/class-common.php:461
+#: src/common/class-common.php:115
+#, php-format
+msgid "%1$s - Message from %2$s():%3$s%4$s%5$s"
+msgstr ""
+
+#: src/common/class-common.php:137
+msgctxt "Successfully emailed from output_to_log()"
+msgid "Email sent."
+msgstr ""
+
+#: src/common/class-common.php:139
+msgctxt "Unsuccessfully emailed from output_to_log()"
+msgid "Email attempted but failed."
+msgstr ""
+
+#: src/common/class-common.php:527
 msgid "Facebook"
 msgstr ""
 
-#: src/common/class-common.php:466
+#: src/common/class-common.php:532
 msgid "Twitter"
 msgstr ""
 
-#: src/common/class-common.php:471
+#: src/common/class-common.php:537
 msgid "Pinterest"
 msgstr ""
 
-#: src/common/class-common.php:476
+#: src/common/class-common.php:542
 msgid "LinkedIn"
 msgstr ""
 

--- a/src/common/class-common.php
+++ b/src/common/class-common.php
@@ -134,9 +134,9 @@ if ( ! class_exists( 'Common' ) ) {
 				$mail_sent = wp_mail( $email, $subject, $email_message );
 
 				if ( $mail_sent ) {
-					$message = esc_html_x( 'Email sent.', 'Successfully emailed from ' . __FUNCTION__ . '()', $this->plugin_text_domain ) . ' ' . $message;
+					$message = esc_html_x( 'Email sent.', 'Successfully emailed from output_to_log()', $this->plugin_text_domain ) . ' ' . $message;
 				} else {
-					$message = esc_html_x( 'Email attempted but failed.', 'Unsuccessfully emailed from ' . __FUNCTION__ . '()', $this->plugin_text_domain ) . ' ' . $message;
+					$message = esc_html_x( 'Email attempted but failed.', 'Unsuccessfully emailed from output_to_log()', $this->plugin_text_domain ) . ' ' . $message;
 				}
 			}
 


### PR DESCRIPTION
Added `output_to_log()` utility function to *Common* to enable writing to `WP_DEBUG_LOG` and optionally send an email, such as to the site administrator.